### PR TITLE
Add docstrings for `make_data_sets` module

### DIFF
--- a/make_data_sets.py
+++ b/make_data_sets.py
@@ -1,9 +1,12 @@
-# Create a DataSet object for each of the programs we track.  
-# Initialize each one with the information it needs to do its query
-# of the database.
-# Store the DataSet objects in a dictionary with keys being the
-# friendly names of the program, which will be used in selection
-# widgets.
+"""
+Create a DataSet object for each of the programs we track.
+Initialize each one with the information it needs to do its query
+of the database.
+
+Store the DataSet objects in a dictionary with keys being the
+friendly names of the program, which will be used in selection
+widgets.
+"""
 
 # In the following line, 'from DataSet' refers to the file DataSet.py
 # while 'import DataSet' refers to the DataSet class within DataSet.py.
@@ -11,6 +14,46 @@
 from ECHO_modules.DataSet import DataSet
 
 def make_data_sets( data_set_list = None ):
+    """
+    Create DataSet objects from a list of preset configurations. This takes a
+    list of preset names and returns a dictionary where the keys are the preset
+    names and values are the DataSet objects that were created with those
+    presets. These presets are an important convenience since DataSet objects
+    are complex with lots of options.
+
+    For example, the preset "RCRA Violations" creates a DataSet from the
+    ``RCRA_VIOLATIONS`` table, indexed by the ``ID_NUMBER`` column, with the
+    date format ``%m/%d/%Y``, and so on.
+
+    Parameters
+    ----------
+    data_set_list : sequence of str
+        A list of preset configuration names for which to construct DataSets.
+        e.g. ``["RCRA Violations", "CAA Enforcements"]``. If not set, this will
+        construct and return a DataSet for every possible preset.
+
+    Returns
+    -------
+    dict
+        A dictionary where the keys are the preset names and the values are
+        the ``DataSet`` objects created from the presets.
+
+    Examples
+    --------
+    >>> make_data_sets(["RCRA Violations", "CAA Enforcements"])
+    {
+        "RCRA Violations":  DataSet(name="RCRA Violations",
+                                    idx_field="ID_NUMBER",
+                                    base_table="RCRA_VIOLATIONS",
+                                    # and so on
+                                   ),
+        "CAA Enforcements": DataSet(name="CAA Enforcements",
+                                    idx_field="REGISTRY_ID",
+                                    base_table="CASE_ENFORCEMENTS",
+                                    # and so on
+                                   ),
+    }
+    """
     data_sets = {}
     ds_name = 'RCRA Violations'
     if ( data_set_list is None or ds_name in data_set_list ):


### PR DESCRIPTION
This adds a docstring for the module (really just turns the existing comment into a docstring) and one for the `make_data_sets()` function.

Will add other docstrings as a separate PR. I wanted to do this one by itself so we can hash out any necessary discussion over the style (these use the [Numpy style](https://numpydoc.readthedocs.io/en/latest/format.html), which is a little verbose, but reads nicely in both code form and generated/parsed docs, and is what we use in all other EDGI python projects). Also, some open questions for discussion about language below.

I didn’t want to change the function or argument names, but looking at the implementation, I realized I had misunderstood what this was supposed to do based on the name and on the video tutorial I’d watched through a bit too quickly. To clarify, I described this as working with “preset configurations,” which seemed clearer to me. Happy to adjust if that doesn’t seem good to you.

In Google Colab, this displays like:

<img width="827" alt="colab-docstring-popup" src="https://user-images.githubusercontent.com/74178/95302708-27ddc180-0837-11eb-9087-7cecc61836e9.png">

---

**Separate but related:** I didn’t make any implementation changes since I wanted to keep the scope narrowly focused on documentation here, but I noticed there’s a lot of repeated boilerplate here. I think it might be useful to rewrite this using a pattern like the following:

```py
# List of presets and their associated options.
#
# These could also be actual `DataSet` objects instead of dicts since
# DataSets don't seem to do anything when constructed and therefore
# aren't too expensive (probably only slightly moreso than these dicts).
# On the other hand, I don't know if there's an expectation that
# repeated calls to `make_data_sets()` should construct new DataSet
# instances. It doesn't look like repeated calling is really intended,
# but I'm not familiar enough with all the notebooks.
# (Also, the dicts are safer for protecting yourself in case a future
# change makes DataSet actually do something at construction time.)
PRESETS = {
    "RCRA Violations": dict(
        idx_field="ID_NUMBER", 
        base_table="RCRA_VIOLATIONS",
        table_name="RCRA_VIOLATIONS_MVIEW",
        echo_type="RCRA",
        date_field="DATE_VIOLATION_DETERMINED",
        date_format="%m/%d/%Y",
        agg_type="count", 
        agg_col="VIOL_DETERMINED_BY_AGENCY", 
        unit="violations"
    ),
    
    "RCRA Inspections": dict(
        idx_field="ID_NUMBER", 
        base_table="RCRA_EVALUATIONS",
        table_name="RCRA_EVALUATIONS_MVIEW",
        echo_type="RCRA",
        date_field="EVALUATION_START_DATE",
        date_format="%m/%d/%Y", 
        agg_type="count",
        agg_col="EVALUATION_AGENCY", 
        unit="inspections"
    ),
    # etc.
}

def make_data_sets(dataset_names=None):
    return {name: DataSet(name=name, **PRESETS[name])
            for name in dataset_names or PRESETS.keys()}
```