### PR TITLE
Update geographies.py

### DIFF
--- a/geographies.py
+++ b/geographies.py
@@ -2,7 +2,8 @@ region_field = {
     'State': { "field": 'FAC_STATE' },
     'Congressional District': { "field": 'FAC_DERIVED_CD113' },
     'County': { "field": 'FAC_COUNTY' },
-    'Zip Code': { "field": 'FAC_ZIP' }
+    'Zip Code': { "field": 'FAC_ZIP' },
+    'Watershed': {"field": 'FAC_DERIVED_HUC'}
 }
 
 states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DC", "DE", "FL", "GA",


### PR DESCRIPTION
updates geographies.py to add a watershed region type using the FAC_DERIVED_HUC field

This will allow us to get and display the full / historical program-specific data based on watersheds rather than just counties, states, districts, etc.