### PR TITLE
Skip slash encoding when saving file

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -494,7 +494,7 @@ def write_dataset( df, base, type, state, regions ):
     if ( df is not None and len( df ) > 0 ):
         if ( not os.path.exists( 'CSVs' )):
             os.makedirs( 'CSVs' )
-        filename = 'CSVs/' + base
+        filename = 'CSVs/' + base[:50]
         if ( type != 'Zip Code' ):
             filename += '-' + state
         filename += '-' + type


### PR DESCRIPTION
This PR fixes Issue #141 in ECHO-Cross-Program (https://github.com/edgi-govdata-archiving/ECHO-Cross-Program/issues/141).
