### PR TITLE
show attribute in choropleth tooltip

### DIFF
--- a/ECHO_modules/utilities.py
+++ b/ECHO_modules/utilities.py
@@ -747,7 +747,7 @@ def choropleth(polygons, attribute, key_id, attribute_table=None, legend_name=No
         line_opacity = 0.2,
         legend_name = legend_name, 
     ).add_to(m)
-    folium.GeoJsonTooltip(fields=[key_id]).add_to(layer.geojson) # Hover over for information
+    folium.GeoJsonTooltip(fields=[key_id, attribute]).add_to(layer.geojson) # Hover over for information
 
     bounds = m.get_bounds()
     m.fit_bounds(bounds)


### PR DESCRIPTION
Something like this: <img width="251" alt="image" src="https://github.com/user-attachments/assets/77818b0c-3501-476c-9ee2-fc7a94c3803a">

I can confirm it works in the case where we are prejoining data, but may not work when `attribute_table` is set because then `attribute` won't be accessible.