### PR TITLE
`get_ejscreen()`

### DIFF
--- a/ECHO_modules/DataSet.py
+++ b/ECHO_modules/DataSet.py
@@ -1,7 +1,4 @@
-import pdb
-
 import os
-import urllib.parse
 import pandas as pd
 from datetime import datetime, date
 from itertools import islice
@@ -55,7 +52,7 @@ class DataSet:
 
     def __init__( self, name, base_table, table_name, echo_type=None,
                  idx_field=None, date_field=None, date_format=None,
-                 sql=None, agg_type=None, agg_col=None, unit=None,
+                 sql=None, agg_type=None, agg_col=None, unit=None, meta=None,
                  api=True, token=None):
         # the echo_type can be a single string--AIR, NPDES, RCRA, SDWA,
         # or a list of multiple strings--['GHG','TRI']
@@ -72,6 +69,7 @@ class DataSet:
         self.unit = unit                    #Unit of measure
         self.sql = sql                      #The SQL query to retrieve the data 
         self.results = {}                   #Dictionary of DataSetResults objects
+        self.meta = meta                    #Link to EPA metadata
         self.last_modified_is_set = False
         self.last_modified = datetime.strptime( '01/01/1970', '%m/%d/%Y')
         self.last_sql = ''

--- a/ECHO_modules/get_data.py
+++ b/ECHO_modules/get_data.py
@@ -1,10 +1,5 @@
-# from dotenv import load_dotenv
-# load_dotenv()
-
-import pdb
 import geopandas
 import os
-import urllib.parse
 import pandas as pd
 import json
 import requests
@@ -70,7 +65,7 @@ def state_abbr_to_fips(state_abbrs):
             return None  # State abbreviation not found
     return fips_codes
 
-def get_spatial_data(region_type, states, spatial_tables, fips=None, region_filter=None):
+def get_spatial_data(region_type, states, fips=None, region_filter=None):
     '''
     Returns spatial data from the database utilizing an intersection query 
 
@@ -80,12 +75,10 @@ def get_spatial_data(region_type, states, spatial_tables, fips=None, region_filt
         The spatial unit to return e.g. "Congressional District" # from cell 3 region_type_widget
     states : list
         The extent across which to get the spatial data e.g. ["AL"]
-    spatial_tables : dict
-        Import from ECHO_modules/geographies.py
     fips : dict
         Optional - Import from ECHO_modules/geographies.py for Census Tracts
     region_filter : list
-        Optional - specify whether to return specific units (e.g. a single county - ["Erie"]). region_filter should be based on the id_field specified in spatial_tables
+        Optional - specify whether to return specific units (e.g. a single county - ["Erie"]). region_filter should be based on the id_field specified in ECHO_modules/geographies.py spatial_tables
 
     Returns
     -------
@@ -93,12 +86,6 @@ def get_spatial_data(region_type, states, spatial_tables, fips=None, region_filt
         GeoDataFrame of the spatial units
     states_gdf
         GeoDataFrame of the state(s) across which the units are selected
-    
-    '''
-    '''
-
-    spatial_tables is from ECHO_modules/geographies.py
-    
     
     '''
     def get_tiger_geojson(query_string, geography_flag):
@@ -126,6 +113,7 @@ def get_spatial_data(region_type, states, spatial_tables, fips=None, region_filt
             "f": "geojson"                     # Return format as GeoJSON
         }
         # The timeout parameter may be necessary 
+        print(base_url[geography_flag], params)
         response = requests.get(base_url[geography_flag], params=params, timeout=10)
         if response.status_code == 200:
             print("Success: retrieved the TIGER geojson!")
@@ -207,7 +195,7 @@ def get_spatial_data(region_type, states, spatial_tables, fips=None, region_filt
       r = requests.get(url)
       z = zipfile.ZipFile(io.BytesIO(r.content))
       z.extractall("/content")
-      regions_gdf = geopandas.read_file("/content/tl_2010_"+f+"_tract10.shp")
+      regions_gdf = geopandas.read_file("/content/tl_2010_"+f+"_tract10.shp") # Mask for region_filter?
       regions_gdf.columns = regions_gdf.columns.str.lower() #convert columns to lowercase for consistency
 
     elif (region_type == "County"):
@@ -378,9 +366,6 @@ def get_echo_data(sql, index_field=None, table_name=None, api=True, token=None):
         print(f"Error: {e}")
         return None
 
-# import requests
-# from tqdm import tqdm
-
 def get_echo_data_delta_api(sql, index_field=None, table_name=None, token=None, backoff_factor=2, retries=5):
     import requests
     from tqdm import tqdm
@@ -528,3 +513,52 @@ def get_echo_api_access_token():
     
     print("❌ Timeout: No token file found within 5 minutes.")
     return None
+
+def get_ejscreen(regions, region_type, state=None, buffer=0, scale="blockgroup", geometries=False):
+  '''
+  Gets EJScreen values for a defined region(s) using the API to EJAM. See here: https://github.com/edgi-govdata-archiving/EJAM-API
+
+  regions : DataSet.region_value, GeoJSON (shape), array of lat/lon (sites), or string or list of FIPS codes (fips)
+  region_type : str - DataSet.region_type ("State", "County", "Watershed", "Zip Code"), "shape", "sites", "fips"
+  state : for Zip/Watershed/County region_type, provide a state abbreviation e.g. "NY"
+  scale : string - either 'blockgroup' or 'county', representing the level at which to return results
+  buffer : integer - miles around the search. Required for "sites" region_type
+  geometries : Boolean - whether to return the shape data for the blockgroups or counties in the search
+
+  Returns a dataframe with EJAM/EJSCREEN results if geometries=False, else a geodataframe with results
+  '''
+  q = {"buffer": buffer, "scale":scale, "geometries":geometries}
+  if region_type == "shape":
+    q["shape"]=regions
+  elif region_type == "sites":
+    q["sites"]=regions
+    if buffer==0:
+      print("For sites (lat/long coordinates), buffer must be >0")
+      return
+  elif (region_type == "fips") or (region_type == "State"):
+    q["fips"]=regions
+  elif region_type in ["Zip Code", "Watershed", "County"]:
+    if type(regions)==list:
+      region_filter = [r.title() for r in regions]
+    elif type(regions)==str:
+      region_filter = regions.title()
+    if state is None:
+      print("Please provide a state like 'NY'")
+                    
+    shapes, stateshape = get_spatial_data(region_type=region_type, region_filter=region_filter, states=[state])
+    q["shape"]=shapes.to_json()
+
+  # Execute data queries
+  import requests, pandas
+  url = "https://ejamapi-84652557241.us-central1.run.app/data"
+  response = requests.post(url, json=q)
+  
+  # Load response
+  df = pandas.DataFrame.from_dict(response.json())
+  
+  # If geometries, load as gdf
+  if geometries:
+    from shapely.geometry import shape
+    df = geopandas.GeoDataFrame(df, geometry=df.pop("geometry").apply(shape), crs=4326)
+
+  return df

--- a/ECHO_modules/get_data.py
+++ b/ECHO_modules/get_data.py
@@ -518,8 +518,8 @@ def get_ejscreen(regions, region_type, state=None, buffer=0, scale="blockgroup",
   '''
   Gets EJScreen values for a defined region(s) using the API to EJAM. See here: https://github.com/edgi-govdata-archiving/EJAM-API
 
-  regions : DataSet.region_value, GeoJSON (shape), array of lat/lon (sites), or string or list of FIPS codes (fips)
-  region_type : str - DataSet.region_type ("State", "County", "Watershed", "Zip Code"), "shape", "sites", "fips"
+  regions : ECHO table/dataframe with FAC_LAT and FAC_LONG (sites), DataSet.region_value ("State", "County", "Watershed", "Zip Code"), GeoJSON (shape), array of lat/lon (sites), or string or list of FIPS codes (fips)
+  region_type : str - ECHO table ("sites"), DataSet.region_type ("State", "County", "Watershed", "Zip Code"), "shape", "sites", "fips"
   state : for Zip/Watershed/County region_type, provide a state abbreviation e.g. "NY"
   scale : string - either 'blockgroup' or 'county', representing the level at which to return results
   buffer : integer - miles around the search. Required for "sites" region_type
@@ -531,6 +531,11 @@ def get_ejscreen(regions, region_type, state=None, buffer=0, scale="blockgroup",
   if region_type == "shape":
     q["shape"]=regions
   elif region_type == "sites":
+    if isinstance(regions, pd.DataFrame):
+      try:
+        regions = [{"lat": fac[0], "lon": fac[1]} for fac in zip(regions["FAC_LAT"], regions["FAC_LONG"])]
+      except:
+        print("ECHO table must contain FAC_LAT and FAC_LONG coordinates")
     q["sites"]=regions
     if buffer==0:
       print("For sites (lat/long coordinates), buffer must be >0")

--- a/ECHO_modules/utilities.py
+++ b/ECHO_modules/utilities.py
@@ -21,7 +21,6 @@ from IPython.display import display
 from ECHO_modules.get_data import get_echo_data
 from ECHO_modules.geographies import region_field, states
 from shapely.geometry import Polygon, Point
-import geopandas as gpd
 
 # Set up some default parameters for graphing
 from matplotlib import cycler
@@ -481,7 +480,7 @@ def filter_by_geometry(points, df):
     max_lat = max(p[1] for p in points)
     
     # Make a geopandas dataframe of all facilities
-    facs_gdf = gpd.GeoDataFrame(df, geometry=gpd.points_from_xy(df['FAC_LONG'], df['FAC_LAT']), crs="EPSG:4269")
+    facs_gdf = geopandas.GeoDataFrame(df, geometry=geopandas.points_from_xy(df['FAC_LONG'], df['FAC_LAT']), crs="EPSG:4269")
     
     filtered_facs = facs_gdf[
         (facs_gdf.geometry.x >= min_lon) & 
@@ -600,7 +599,6 @@ def aggregate_by_facility(records, program, other_records = False, api=True, tok
   else:
     print( "There is no data for this program and region after 2000." )
 
-# IGNORE 
 def aggregate_by_geography(dsr, agg_type, spatial_tables, region_filter=None):
     '''
     Aggregate attribute data by a spatial unit, such as zip codes
@@ -631,7 +629,7 @@ def aggregate_by_geography(dsr, agg_type, spatial_tables, region_filter=None):
     ## Get spatial data
     if region_filter and dsr.region_type == "County":
         region_filter = [c.title() for c in region_filter]
-    regions, states = get_spatial_data(dsr.region_type, dsr.state, spatial_tables, region_filter=region_filter)
+    regions, states = get_spatial_data(dsr.region_type, dsr.state, region_filter=region_filter)
     ## Join
     if dsr.region_type == "County":
         idx = regions[spatial_tables[dsr.region_type]['match_field']].str.upper()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+	"delta-spark==3.3.0",
+	"deltalake==0.16.4",
 	"folium>=0.14.0",
 	"geopandas>=0.9.0",
 	"ipyleaflet==0.19.2",
@@ -30,8 +32,10 @@ dependencies = [
 	"matplotlib>=3.4.3",
 	"numpy==2.0.2",
 	"pandas>=1.3.4",
+	"pyspark>=3.5.4",
 	"requests>=2.31.0",
-	"seaborn>=0.11.2"
+	"seaborn>=0.11.2",
+	"tqdm"
 ]
 
 [project.urls]


### PR DESCRIPTION
This adds a wrapper function for the EJAM-API, making it fairly easy to get EJSCREEN values for sites of interest in ECHO.

```
def get_ejscreen(regions, region_type, state=None, buffer=0, scale="blockgroup", geometries=False):
  '''
  Gets EJScreen values for a defined region(s) using the API to EJAM. See here: https://github.com/edgi-govdata-archiving/EJAM-API

  regions : ECHO table/dataframe with FAC_LAT and FAC_LONG (sites), DataSet.region_value ("State", "County", "Watershed", "Zip Code"), GeoJSON (shape), array of lat/lon (sites), or string or list of FIPS codes (fips)
  region_type : str - ECHO table ("sites"), DataSet.region_type ("State", "County", "Watershed", "Zip Code"), "shape", "sites", "fips"
  state : for Zip/Watershed/County region_type, provide a state abbreviation e.g. "NY"
  scale : string - either 'blockgroup' or 'county', representing the level at which to return results
  buffer : integer - miles around the search. Required for "sites" region_type
  geometries : Boolean - whether to return the shape data for the blockgroups or counties in the search

  Returns a dataframe with EJAM/EJSCREEN results if geometries=False, else a geodataframe with results
  '''
  q = {"buffer": buffer, "scale":scale, "geometries":geometries}
  if region_type == "shape":
    q["shape"]=regions
  elif region_type == "sites":
    if isinstance(regions, pd.DataFrame):
      try:
        regions = [{"lat": fac[0], "lon": fac[1]} for fac in zip(regions["FAC_LAT"], regions["FAC_LONG"])]
      except:
        print("ECHO table must contain FAC_LAT and FAC_LONG coordinates")
    q["sites"]=regions
    if buffer==0:
      print("For sites (lat/long coordinates), buffer must be >0")
      return
  elif (region_type == "fips") or (region_type == "State"):
    q["fips"]=regions
  elif region_type in ["Zip Code", "Watershed", "County"]:
    if type(regions)==list:
      region_filter = [r.title() for r in regions]
    elif type(regions)==str:
      region_filter = regions.title()
    if state is None:
      print("Please provide a state like 'NY'")
                    
    shapes, stateshape = get_spatial_data(region_type=region_type, region_filter=region_filter, states=[state])
    q["shape"]=shapes.to_json()

  # Execute data queries
  import requests, pandas
  url = "https://ejamapi-84652557241.us-central1.run.app/data"
  response = requests.post(url, json=q)
  
  # Load response
  df = pandas.DataFrame.from_dict(response.json())
  
  # If geometries, load as gdf
  if geometries:
    from shapely.geometry import shape
    df = geopandas.GeoDataFrame(df, geometry=df.pop("geometry").apply(shape), crs=4326)

  return df
```

Example uses:

```
# EJSCREEN scores for 1 mile buffers around all active CAA facilities in Erie County, NY
from ECHO_modules.utilities import get_active_facilities # Use the get_active_facilities function

erie = get_active_facilities("NY", "County", ["ERIE"])
erie_air = erie[erie["AIR_FLAG"]=="Y"]]
erie_air_gdf = get_ejscreen(regions=erie_air, region_type="sites", geometries=True, buffer=1)
erie_air_gdf
```

```
# Get EJSCREEN scores for two Iowa zip codes then map one of the scores
from ECHO_modules.make_data_sets import make_data_sets

data_sets = make_data_sets([
    "RCRA Violations"
])
zip_rcra_violations = data_sets["RCRA Violations"].store_results(
    region_type="Zip Code", region_value=["52358", "52240"], state="IA",
    years=[2010,2020])
df = get_ejscreen(regions=zip_rcra_violations.region_value, region_type=zip_rcra_violations.region_type, state=zip_rcra_violations.state, geometries=True)

from ECHO_modules.utilities import choropleth
choropleth(polygons=df, attribute="state.EJ.DISPARITY.traffic.score.supp", key_id="ejam_uniq_id")
```